### PR TITLE
Written tests for FreeBSD. 

### DIFF
--- a/src/ifcfg/__init__.py
+++ b/src/ifcfg/__init__.py
@@ -6,7 +6,7 @@ import platform
 from . import tools
 from . import parser
 
-__version__ = "0.14"
+__version__ = "0.14.1"
 
 Log = tools.minimal_logger(__name__)
 

--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -209,7 +209,7 @@ class UnixParser(Parser):
     @classmethod
     def get_patterns(cls):
         return [
-            '(?P<device>^[a-zA-Z0-9:]+): flags=(?P<flags>.*) mtu (?P<mtu>.*)',
+            '(?P<device>^[a-zA-Z0-9:_-]+): flags=(?P<flags>.*) mtu (?P<mtu>.*)',
             '.*inet\s+(?P<inet>[\d\.]+).*',
             '.*inet6\s+(?P<inet6>[\d\:abcdef]+).*',
             '.*broadcast (?P<broadcast>[^\s]*).*',

--- a/tests/ifconfig_out.py
+++ b/tests/ifconfig_out.py
@@ -85,3 +85,36 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 169.254.0.0     0.0.0.0         255.255.0.0     U     1000   0        0 eth0
 192.168.1.0     0.0.0.0         255.255.255.0   U     600    0        0 eth0
 """
+
+FREEBSD = """
+iflan0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+        options=9b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM>
+        ether 00:50:56:80:7f:2a
+        inet 192.168.0.1 netmask 0xfffffc00 broadcast 192.168.3.255
+        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
+        media: Ethernet autoselect (1000baseT <full-duplex>)
+        status: active
+ifwan0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+        options=60039b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM,TSO4,TSO6,RXCSUM_IPV6,TXCSUM_IPV6>
+        ether 00:50:56:80:56:57
+        inet 10.0.0.6 netmask 0xfffffffc broadcast 10.0.0.7
+        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
+        media: Ethernet autoselect
+        status: active
+ifcli715: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+        options=60039b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM,TSO4,TSO6,RXCSUM_IPV6,TXCSUM_IPV6>
+        ether 00:50:56:80:14:68
+        inet 10.0.106.254 netmask 0xffffff00 broadcast 10.0.106.255
+        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
+        media: Ethernet autoselect
+        status: active
+pflog0: flags=141<UP,RUNNING,PROMISC> metric 0 mtu 33160
+pfsync0: flags=0<> metric 0 mtu 1500
+        syncpeer: 0.0.0.0 maxupd: 128 defer: off
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
+        options=600003<RXCSUM,TXCSUM,RXCSUM_IPV6,TXCSUM_IPV6>
+        inet6 ::1 prefixlen 128
+        inet6 fe80::1%lo0 prefixlen 64 scopeid 0x6
+        inet 127.0.0.1 netmask 0xff000000
+        nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
+""" # noqa

--- a/tests/ifconfig_out.py
+++ b/tests/ifconfig_out.py
@@ -42,6 +42,16 @@ lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 16436
         TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
 """
 
+LINUX4 = """
+br-339b29e0f3aa: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 192.168.0.1  netmask 255.255.255.0  broadcast 192.168.0.255
+        ether 02:42:64:80:dd:3e  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+"""
+
 LINUX = LINUX3
 
 

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -84,6 +84,28 @@ class IfcfgTestCase(IfcfgTestCase):
         eq_(interfaces['en0']['broadcast'], '192.168.0.255')
         eq_(interfaces['en0']['netmask'], '255.255.255.0')
 
+    def test_FreeBSD(self):
+        ifcfg.distro = 'FreeBSD'
+        ifcfg.Parser = ifcfg.get_parser_class()
+        parser = ifcfg.get_parser(ifconfig=ifconfig_out.FREEBSD)
+        interfaces = parser.interfaces
+        self.assertEqual(len(interfaces.keys()), 5)
+        # iflan0
+        eq_(interfaces['iflan0']['ether'], '00:50:56:80:7f:2a')
+        eq_(interfaces['iflan0']['inet'], '192.168.0.1')
+        eq_(interfaces['iflan0']['broadcast'], '192.168.3.255')
+        eq_(interfaces['iflan0']['netmask'], 22)
+        # ifwan0
+        eq_(interfaces['ifwan0']['ether'], '00:50:56:80:56:57')
+        eq_(interfaces['ifwan0']['inet'], '10.0.0.6')
+        eq_(interfaces['ifwan0']['broadcast'], '10.0.0.7')
+        eq_(interfaces['ifwan0']['netmask'], 30)
+        # ifcli715
+        eq_(interfaces['ifcli715']['ether'], '00:50:56:80:14:68')
+        eq_(interfaces['ifcli715']['inet'], '10.0.106.254')
+        eq_(interfaces['ifcli715']['broadcast'], '10.0.106.255')
+        eq_(interfaces['ifcli715']['netmask'], 24)
+
     def test_default_interface(self):
         ifcfg.distro = 'Linux'
         ifcfg.Parser = ifcfg.get_parser_class()

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -62,6 +62,17 @@ class IfcfgTestCase(IfcfgTestCase):
         eq_(interfaces['eth0']['broadcast'], '192.168.0.255')
         eq_(interfaces['eth0']['netmask'], '255.255.255.0')
 
+    def test_linux4(self):
+        ifcfg.distro = 'Linux'
+        ifcfg.Parser = ifcfg.get_parser_class()
+        parser = ifcfg.get_parser(ifconfig=ifconfig_out.LINUX4)
+        interfaces = parser.interfaces
+        self.assertEqual(len(interfaces.keys()), 1)
+        eq_(interfaces['br-339b29e0f3aa']['ether'], '02:42:64:80:dd:3e')
+        eq_(interfaces['br-339b29e0f3aa']['inet'], '192.168.0.1')
+        eq_(interfaces['br-339b29e0f3aa']['broadcast'], '192.168.0.255')
+        eq_(interfaces['br-339b29e0f3aa']['netmask'], '255.255.255.0')
+
     def test_macosx(self):
         ifcfg.distro = 'MacOSX'
         ifcfg.Parser = ifcfg.get_parser_class()


### PR DESCRIPTION
Fixed error in tests::cli_tests.py when device name contains '-' 
Written tests for FreeBSD. 